### PR TITLE
Replace copied navigation items with documentation links

### DIFF
--- a/src/components/ui-components/Header.vue
+++ b/src/components/ui-components/Header.vue
@@ -9,14 +9,12 @@
         </div>
         <nav>
           <ul class="nav-menu" role="navigation">
-            <li><a href="/guides">Guides</a></li>
-            <li><a href="/documentation">Documentation</a></li>
-            <li><a href="/gallery">Gallery</a></li>
-            <li><a href="/download">Download</a></li>
-            <li><a href="/about">About</a></li>
+            <li><a target="_blank" href="https://oskari.org/documentation">Documentation: </a></li> {
+            <li><a target="_blank" href="https://oskari.org/documentation/api/requests">Requests</a></li> | 
+            <li><a target="_blank" href="https://oskari.org/documentation/api/events">Events</a></li>}
           </ul>
         </nav>
-        <button class="nav-download">Download</button>
+        <a href="https://oskari.org/download" class="nav-download" role="button">Download</a>
       </div>
     </div>
   </div>
@@ -90,7 +88,8 @@ export default {
   letter-spacing: var(--l-spacing);
   border-radius: 50rem;
   border-color: transparent;
-  padding: 0.6rem 1.6rem;
+  padding: 0.8rem 1.6rem;
+  text-decoration: none;
 }
 
 .nav-download:hover {

--- a/src/pages/GettingStarted.vue
+++ b/src/pages/GettingStarted.vue
@@ -4,10 +4,10 @@
     <h3>Including the necessary stuff to get RPC up and running</h3>
     <ul class="nav nav-tabs" id="myTab" role="tablist">
       <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="npm-tab" data-bs-toggle="tab" data-bs-target="#npm" type="button" role="tab" aria-controls="JavaScript" aria-selected="true">NPM</button>
+        <button class="nav-link active" id="npm-tab" data-bs-toggle="tab" data-bs-target="#npm" type="button" role="tab" aria-controls="JavaScript" aria-selected="true">npm</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="JavaScript-tab" data-bs-toggle="tab" data-bs-target="#JavaScript" type="button" role="tab" aria-controls="JavaScript" aria-selected="false">&lt;SCRIPT&gt;</button>
+        <button class="nav-link" id="JavaScript-tab" data-bs-toggle="tab" data-bs-target="#JavaScript" type="button" role="tab" aria-controls="JavaScript" aria-selected="false">&lt;script&gt;</button>
       </li>
     </ul>
     <div class="tab-content" id="myTabContent">


### PR DESCRIPTION
From (broken links):
![image](https://github.com/user-attachments/assets/969411a7-f711-41b4-89b3-f25c56061660)

To (documentation links):
![image](https://github.com/user-attachments/assets/4cca8f09-879f-43ab-86d0-aab6de147114)
